### PR TITLE
Fix env template names

### DIFF
--- a/starfish/.env.template
+++ b/starfish/.env.template
@@ -1,2 +1,2 @@
-export SECRET_KEY=''
-export CONTACT_HASH_SALT=''
+export DJANGO_SECRET_KEY=''
+export DJANGO_CONTACT_HASH_SALT=''

--- a/starfish/install.sh
+++ b/starfish/install.sh
@@ -2,13 +2,16 @@
 set -e
 set -x
 
-cp .env.template .env 
+if [ ! -f ./.env ]; then
+    cp .env.template .env 
+    read -p "You will need to edit .env to add your secret keys. Press Enter to confirm you understand and continue."
+fi
 
-read -p "You will need to edit .env to add your secret keys. Press Enter to confirm you understand and continue."
 
 python3 -m venv .venv
 source .venv/bin/activate
 
+source ./.env
 pip install -r requirements.txt
 pip install -r requirements_dev.txt
 


### PR DESCRIPTION
My last PR somehow didn't have the correct environment variable names in `.env.template`. I discovered that when I re-ran the `install.sh` because it replaced my existing `.env` file with the template.

There are two fixes in the PR, one that makes the template have the correct names and the other makes the install script only copy the template when `.env` doesn't exist as well as sourcing it the same way `dev.sh` does so that the commands complete.