### PR TITLE
CI improvements for docs

### DIFF
--- a/.github/shared/build_docs_pages/action.yml
+++ b/.github/shared/build_docs_pages/action.yml
@@ -1,0 +1,28 @@
+name: Build Docs Pages
+description: Build Docs Pages for mkdocs workflows.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
+      with:
+        python-version: 3.12
+        cache: "pip"
+
+    - name: Configure venv
+      run: python3 -m venv "./.venv"
+      shell: bash
+
+    - name: Activate venv
+      run: |
+        . "./.venv/bin/activate"
+        echo PATH=$PATH >> $GITHUB_ENV
+      shell: bash
+
+    - name: Install Dependencies
+      run: pip install -r "mkdocs-requirements.txt"
+      shell: bash
+
+    - name: Build Pages # this is both a build and check step
+      run: mkdocs build --strict
+      shell: bash

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -1,0 +1,25 @@
+name: docs
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+jobs:
+  check_markdown:
+    uses: "./.github/workflows/reusable_check_markdown.yml"
+    with:
+      globs: "docs/**/*.md"
+  check_docs:
+    needs: check_markdown
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          fetch-depth: 0 # mkdocs-git-revision-date-localized-plugin
+      - uses: "./.github/shared/build_docs_pages/"

--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -1,61 +1,39 @@
-name: ci
+name: python
 
 on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+    paths:
+      - "**.py"
   pull_request:
     branches:
       - main
+    paths:
+      - "**.py"
   workflow_dispatch:
-    branches:
-      - main
 
 jobs:
-  check:
+  check_python:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-
-      - name: Black Lint
-        uses: psf/black@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # 25.1.0
         with:
           options: "--check --diff --verbose"
           src: "starfish/"
           version: "~=25.1"
-
-      - name: isort Lint
-        uses: isort/isort-action@v1
+      - uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # 1.1.1
         with:
           configuration: "--check-only --diff"
           isort-version: "6.0"
           requirements-files: "starfish/requirements.txt starfish/requirements-dev.txt"
           sort-paths: "starfish/"
-
-      - name: Flake8 Lint
-        uses: py-actions/flake8@v2
+      - uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # 2.3.0
         with:
           args: "--toml-config=pyproject.toml"
           flake8-version: "7.2"
           path: "starfish/"
           plugins: "flake8-pyproject>=1.2,<2"
-
-      - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v16
-        with:
-          config: .markdownlint-cli2.jsonc
-          globs: "**/*.md"
-
-      - name: Yamllint
-        uses: karancode/yamllint-github-action@master
-        with:
-          yamllint_strict: true
-          yamllint_comment: true

--- a/.github/workflows/check_yaml.yml
+++ b/.github/workflows/check_yaml.yml
@@ -1,0 +1,29 @@
+name: yaml
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+    paths:
+      - "**.yml"
+      - "**.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.yml"
+      - "**.yaml"
+  workflow_dispatch:
+
+jobs:
+  check_yaml:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 # 3.0.0
+        with:
+          yamllint_config_filepath: ".yamllint.yaml"
+          yamllint_strict: true
+          yamllint_comment: true

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,35 @@
+name: docs
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+jobs:
+  check_markdown:
+    uses: "./.github/workflows/reusable_check_markdown.yml"
+    with:
+      globs: "docs/**/*.md"
+  deploy_docs:
+    needs: check_markdown
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          fetch-depth: 0 # mkdocs-git-revision-date-localized-plugin
+      - uses: "./.github/shared/build_docs_pages/"
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # 5.0.0
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # 3.0.1
+        with:
+          path: "./site"
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # 4.0.5

--- a/.github/workflows/reusable_check_markdown.yml
+++ b/.github/workflows/reusable_check_markdown.yml
@@ -1,0 +1,53 @@
+name: markdown
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+      - "!docs/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.md"
+      - "!docs/**"
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      globs:
+        type: string
+
+jobs:
+  check_markdown:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - name: Configure Globs
+        id: globs
+        run: |
+          if [ -n "${{ inputs.globs }}" ]; then
+            GLOBS_STRING="${{ inputs.globs }}"
+          else
+            GLOBS_STRING='**/*.md !docs/**/*.md'
+          fi
+
+          IFS=' ' read -r -a GLOBS_ARRAY <<< "$GLOBS_STRING"
+          NEWLINE_DELIMITED_GLOBS=""
+          for glob in "${GLOBS_ARRAY[@]}"; do
+            if [ -n "$NEWLINE_DELIMITED_GLOBS" ]; then
+              NEWLINE_DELIMITED_GLOBS+=$'\n'
+            fi
+            NEWLINE_DELIMITED_GLOBS+="$glob"
+          done
+
+          echo "globs<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NEWLINE_DELIMITED_GLOBS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # 20.0.0
+        with:
+          config: ".markdownlint-cli2.jsonc"
+          globs: "${{ steps.globs.outputs.globs }}"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,8 @@
 {
   "fix": false,
   "ignores": [
-    ".git/"
+    ".git/",
+    ".venv/",
+    "starfish/.venv/"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,14 @@ repos:
         additional_dependencies: ["flake8-pyproject>=1.2,<2"]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.13.0
+    rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
         require_serial: true
+        args: [--config, ".markdownlint-cli2.jsonc"]
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.37.1
     hooks:
       - id: yamllint
-        args: [-c, .yamllint.yaml, --strict]
+        args: [-c, ".yamllint.yaml", --strict]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Available at <https://gs-us.github.io/strikecard-backend/>.
 
 Defined in [`mkdocs.yml`](./mkdocs.yml). Controls navigation layout in the rendered docs.
 
+### Docs Local Build
+
+Build locally as described in [`INSTALL.md`](starfish/INSTALL.md#working-with-the-docs).
+
 ### Docs Content
 
 Defined in [`docs/`](docs/).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ See [`starfish/INSTALL.md`](./starfish/INSTALL.md) for more information about in
 
 ### Configuration
 
-Defined in [`pyproject.toml`](./pyproject.toml).
+Defined in the following files.
+
+- [`pyproject.toml`](./pyproject.toml)
+    - `black`
+    - `isort`
+    - `flake8`
+- [`.markdownlint.json`](./markdownlint.json) and [`.markdownlint-cli2.jsonc`](./markdownlint-cli2.jsonc)
+    - `markdownlint`
+- [`.yamllint.yaml`](./.yamllint.yaml)
+    - `yamllint`
 
 ### Pre-Commit
 
@@ -34,9 +43,9 @@ Runs the following repo hooks:
 
 ### Continuous Integration (CI)
 
-Defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+Defined in [`.github/`](.github/).
 
-Runs the following actions:
+Runs the following actions dependent on what files are modified.
 
 - Black (format linting)
 - isort (format linting)
@@ -44,4 +53,23 @@ Runs the following actions:
 - markdownlint (linting)
 - yamllint (linting)
 
-Intended to mirror [pre-commit](#pre-commit).
+Intended to mirror [pre-commit](#pre-commit) effects.
+
+Checks and deploys the docs for any changes to files in `./docs/`.
+
+## Documentation
+
+Available at <https://gs-us.github.io/strikecard-backend/>.
+
+### Docs Configuration
+
+Defined in [`mkdocs.yml`](./mkdocs.yml). Controls navigation layout in the rendered docs.
+
+### Docs Content
+
+Defined in [`docs/`](docs/).
+
+#### Blog, News, and Notes
+
+Please give a date-based name with a title like `yyyy-mm-dd-title.md` and put in
+[`docs/blog/posts/`](docs/blog/posts/).


### PR DESCRIPTION
I had to do a lot of work on the CI to get it where I wanted, but worth it.

- Split `ci.yml` into multiple workflows
    - `check_python.yml` for the existing workflow
    - `check_yaml.yml` for YAML linting
    - `reusable_check_markdown.yml` for Markdown linting
    - `check_docs.yml` to run `mkdocs build --strict` to check for errors. Uses `reusable_check_markdown.yml`.
    - `deploy_docs.yml` to build and deploy the docs. Uses `reusable_check_markdown.yml`.
    - A shared composite workflow `build_docs_pages` that is used by both docs checking and deployment.
- Clean pre-commit and bump versions.
- Add ignores for `markdownlint-cli2`, it was linting files in `.venv` (mostly licenses and readmes).
- Update readme with relevant information.

Each action is only run if a relevant file is modified or added, determined by extension (for linting) and `docs/` for docs check and deployment.