### PR TITLE
Swap "Change" to "View" on ChapterZipAdmin

### DIFF
--- a/starfish/chapters/admin.py
+++ b/starfish/chapters/admin.py
@@ -151,3 +151,6 @@ class ChapterZipAdmin(ModelAdmin):
             return [field.name for field in obj._meta.fields]
         else:
             return []
+
+    def has_change_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
fixes #71
There isn't really anything to alter about a Chapter ZIP once it's created, but Django assumes you want to edit it. The fix here is to find a way to override the title of the changelist and update views.